### PR TITLE
Use ESM loading instead of CommonJS

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,6 @@ async function run(dependencyOverrides) {
 
 // Export is only used for testing
 module.exports = run;
-module.exports.run = run;
 module.exports.loadDependencies = loadDependencies;
 
 if (require.main === module) {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,19 @@
-const core = require('@actions/core');
-const github = require('@actions/github');
+async function loadDependencies() {
+    const [core, github] = await Promise.all([
+        import('@actions/core'),
+        import('@actions/github'),
+    ]);
 
-async function run() {
+    return { core, github };
+}
+
+async function run(dependencyOverrides) {
+    let core;
+
     try {
+        const { core: loadedCore, github } = dependencyOverrides || await loadDependencies();
+        core = loadedCore;
+
         const context = github.context;
 
         const allowedEvents = ['pull_request', 'pull_request_target'];
@@ -50,12 +61,19 @@ async function run() {
             return;
         }
 
-        core.setFailed(error.message);
+        if (core && typeof core.setFailed === 'function') {
+            core.setFailed(error.message);
+            return;
+        }
+
+        throw error;
     }
 }
 
 // Export is only used for testing
 module.exports = run;
+module.exports.run = run;
+module.exports.loadDependencies = loadDependencies;
 
 if (require.main === module) {
     run();

--- a/index.test.js
+++ b/index.test.js
@@ -1,18 +1,21 @@
-jest.mock('@actions/core', () => ({
-    getInput: jest.fn(),
-    setFailed: jest.fn(),
-}), { virtual: true });
-
-jest.mock('@actions/github', () => ({
-    context: {},
-    getOctokit: jest.fn(),
-}), { virtual: true });
-
-const core = require('@actions/core');
-const github = require('@actions/github');
 const run = require('./index');
 
 describe('remove-safe-to-test-label', () => {
+    let core;
+    let github;
+
+    beforeEach(() => {
+        core = {
+            getInput: jest.fn(),
+            setFailed: jest.fn(),
+        };
+
+        github = {
+            context: {},
+            getOctokit: jest.fn(),
+        };
+    });
+
     afterEach(() => {
         jest.clearAllMocks();
     });
@@ -57,7 +60,7 @@ describe('remove-safe-to-test-label', () => {
             },
         });
 
-        await run();
+        await run({ core, github });
 
         expect(github.getOctokit).toHaveBeenCalledWith('fake-token');
         expect(github.getOctokit().rest.issues.removeLabel).toHaveBeenCalledWith({
@@ -108,7 +111,7 @@ describe('remove-safe-to-test-label', () => {
             },
         });
 
-        await run();
+        await run({ core, github });
 
         expect(github.getOctokit).toHaveBeenCalledTimes(0);
         expect(github.getOctokit().rest.issues.removeLabel).toHaveBeenCalledTimes(0);
@@ -138,24 +141,20 @@ describe('remove-safe-to-test-label', () => {
         github.context.payload = payload;
 
         core.getInput.mockReturnValue('safe-to-test');
-        await run();
+        await run({ core, github });
 
         expect(core.setFailed).toHaveBeenCalledTimes(0);
         expect(github.getOctokit).toHaveBeenCalledTimes(0);
     });
 
     test('should fail when there is an error', async () => {
-        const errorMessage = 'An error occurred';
         github.context.eventName = 'pull_request';
         github.context.payload = null;
 
         core.getInput.mockReturnValue('safe-to-test');
 
-        try {
-            await run();
-        } catch (error) {
-            expect(core.setFailed).toHaveBeenCalledWith(errorMessage);
-        }
+        await run({ core, github });
+        expect(core.setFailed).toHaveBeenCalledTimes(1);
     });
 
     test('should handle the error when the label does not exist', async () => {
@@ -201,7 +200,7 @@ describe('remove-safe-to-test-label', () => {
             },
         });
 
-        await run();
+        await run({ core, github });
 
         expect(mockRemoveLabel).toHaveBeenCalledWith({
             owner: 'base-owner',


### PR DESCRIPTION
### What I changed

  - Replaced top-level CommonJS require('@actions/core') / require('@actions/github') with runtime ESM loading via import() in index.js
  - Added loadDependencies() and made run() accept optional injected deps for tests in index.js 
  - Kept the action entrypoint behavior (if (require.main === module) run();) intact in index.js
  - Updated tests to inject mocked core/github objects directly instead of jest.mock('@actions/*') in index.test.js

  This resolves the ERR_PACKAGE_PATH_NOT_EXPORTED issue on Node 24 while keeping current dependency versions.