### PR TITLE
Improved error message when workflow lacks required permissions

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,17 @@ function isLabelAlreadyGoneError(error) {
     return error?.message === 'Label does not exist' || error?.status === 404;
 }
 
+function isMissingIntegrationPermissionError(error) {
+    return error?.status === 403
+        && typeof error?.message === 'string'
+        && error.message.includes('Resource not accessible by integration');
+}
+
 function getFailureMessage(error) {
+    if (isMissingIntegrationPermissionError(error)) {
+        return 'Failed to remove label because the workflow token lacks required permissions. Ensure your workflow grants `contents: read` and `pull-requests: write`.';
+    }
+
     return error instanceof Error ? error.message : String(error);
 }
 
@@ -111,6 +121,7 @@ module.exports._internals = {
     ALLOWED_EVENTS,
     getFailureMessage,
     isLabelAlreadyGoneError,
+    isMissingIntegrationPermissionError,
     pullRequestHasLabel,
     shouldSkipEvent,
     shouldSkipNonForkPullRequest,

--- a/index.test.js
+++ b/index.test.js
@@ -120,6 +120,23 @@ describe('remove-safe-to-test-label', () => {
             'Missing pull request repository metadata in workflow payload.',
         );
     });
+
+    test('fails with a helpful message when token permissions are missing', async () => {
+        const permissionError = new Error(
+            'Resource not accessible by integration - https://docs.github.com/rest/issues/labels#remove-a-label-from-an-issue',
+        );
+        permissionError.status = 403;
+
+        const { core, github } = setup({
+            removeLabel: jest.fn().mockRejectedValue(permissionError),
+        });
+
+        await run({ core, github });
+
+        expect(core.setFailed).toHaveBeenCalledWith(
+            'Failed to remove label because the workflow token lacks required permissions. Ensure your workflow grants `contents: read` and `pull-requests: write`.',
+        );
+    });
 });
 
 function buildForkPayload({ labels = [{ name: 'safe-to-test' }] } = {}) {


### PR DESCRIPTION
<img width="1271" height="200" alt="image" src="https://github.com/user-attachments/assets/e7200381-4c33-4725-9b70-f3225901a8a8" />
